### PR TITLE
Better handling of parameter extraction

### DIFF
--- a/src/com/nvlad/yii2support/common/DatabaseUtils.java
+++ b/src/com/nvlad/yii2support/common/DatabaseUtils.java
@@ -100,7 +100,7 @@ public class DatabaseUtils {
 
     public static String[] extractParamsFromCondition(String condition, boolean includeColon) {
         LinkedHashSet<String> matches = new LinkedHashSet<>();
-        String pattern = "(?<![:\\[])(:\\w+)";
+        String pattern = "(?<![:\\[])(:[^\\W\\d]\\w+)";
         Pattern r = Pattern.compile(pattern);
         Matcher m = r.matcher(condition);
         while (m.find()) {


### PR DESCRIPTION
To avoid matching dates containing times, a parameter has to start with a "letter". (Alphanums without nums)