### PR TITLE
Case insensitive dateFromName Pattern

### DIFF
--- a/src/com/nvlad/yii2support/migrations/entities/Migration.java
+++ b/src/com/nvlad/yii2support/migrations/entities/Migration.java
@@ -40,7 +40,7 @@ public class Migration implements Comparable<Migration> {
         return createdAt.compareTo(migration.createdAt);
     }
 
-    private static final Pattern dateFromName = Pattern.compile("m(\\d{6}_\\d{6})_.*");
+    private static final Pattern dateFromName = Pattern.compile("m(\\d{6}_\\d{6})_.*", Pattern.CASE_INSENSITIVE);
     private static final SimpleDateFormat migrationCreateDateFormat = new SimpleDateFormat("yyMMdd_HHmmss");
 
     @Nullable


### PR DESCRIPTION
The default Yii2 regex is case insensitive (yiisoft/yii2/console/controllers/BaseMigrateController.php:903 `/^(m(\d{6}_?\d{6})\D.*?)\.php$/is`).

Fixes: #196